### PR TITLE
Fix Syntax Conformance Tests

### DIFF
--- a/Civi/API/SelectQuery.php
+++ b/Civi/API/SelectQuery.php
@@ -123,8 +123,7 @@ abstract class SelectQuery {
     $this->buildSelectFields();
 
     $this->buildWhereClause();
-
-    if (in_array('count', $this->select)) {
+    if (in_array('count_rows', $this->select)) {
       $this->query->select("count(*) as c");
     }
     else {
@@ -144,7 +143,7 @@ abstract class SelectQuery {
     $result_dao = \CRM_Core_DAO::executeQuery($this->query->toSQL());
 
     while ($result_dao->fetch()) {
-      if (in_array('count', $this->select)) {
+      if (in_array('count_rows', $this->select)) {
         $result_dao->free();
         return (int) $result_dao->c;
       }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -176,13 +176,8 @@ function civicrm_api3_create_success($values = 1, $params = array(), $entity = N
         $values[$key]['id'] = $item[$lowercase_entity . "_id"];
       }
       if (!empty($item['financial_type_id'])) {
-        // 4.3 legacy handling - translate financial_type to contribution_type unless financial_type is explicitly specified.
-        if (!is_array($params) || empty($params['return']) || !is_array($params['return']) ||
-          (empty($params['return']['financial_type_id']) && !in_array('financial_type_id', $params['return'])) ||
-          (!empty($params['return']['contribution_type_id']) || in_array('contribution_type_id', $params['return']))
-        ) {
-          $values[$key]['contribution_type_id'] = $item['financial_type_id'];
-        }
+        // 4.3 legacy handling.
+        $values[$key]['contribution_type_id'] = $item['financial_type_id'];
       }
       if (!empty($item['next_sched_contribution_date'])) {
         // 4.4 legacy handling
@@ -1347,7 +1342,7 @@ function _civicrm_api3_basic_get($bao_name, $params, $returnAsSuccess = TRUE, $e
   $query = new \Civi\API\Api3SelectQuery($entity, CRM_Utils_Array::value('check_permissions', $params, FALSE));
   $query->where = $params;
   if ($options['is_count']) {
-    $query->select = array('count');
+    $query->select = array('count_rows');
   }
   else {
     $query->select = array_keys(array_filter($options['return']));

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -1282,6 +1282,10 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         //api has special handling on these 2 fields for backward compatibility reasons
         $entity['contribution_type_id'] = $updateParams['financial_type_id'];
       }
+      if (isset($updateParams['next_sched_contribution_date']) && in_array($entityName, array('ContributionRecur'))) {
+        //api has special handling on these 2 fields for backward compatibility reasons
+        $entity['next_sched_contribution'] = $updateParams['next_sched_contribution_date'];
+      }
 
       $update = $this->callAPISuccess($entityName, 'create', $updateParams);
       $checkParams = array(
@@ -1311,6 +1315,10 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
         if (isset($updateParams['financial_type_id']) && in_array($entityName, array('Grant'))) {
           //api has special handling on these 2 fields for backward compatibility reasons
           $entity['contribution_type_id'] = $updateParams['financial_type_id'];
+        }
+        if (isset($updateParams['next_sched_contribution_date']) && in_array($entityName, array('ContributionRecur'))) {
+          //api has special handling on these 2 fields for backward compatibility reasons
+          $entity['next_sched_contribution'] = $updateParams['next_sched_contribution_date'];
         }
       }
     }


### PR DESCRIPTION
@colemanw @eileenmcnaughton 

So the 3 fixes here are 
1. We need to always output contribution_type_id in v3 which is the same as fianncial_type_id 
2. I have got around the PriceFieldValue having a column called count by changing it to be count_rows for the select 
3. adding in special handling in the syntaxConformanceTest for the next_sched_contribution
