### PR TITLE
Pass `menubar_color` as a param. Simplify cache mechanics.

### DIFF
--- a/CRM/Admin/Form/Preferences/Display.php
+++ b/CRM/Admin/Form/Preferences/Display.php
@@ -106,8 +106,6 @@ class CRM_Admin_Form_Preferences_Display extends CRM_Admin_Form_Preferences {
 
     $this->postProcessCommon();
 
-    \Civi::service('asset_builder')->clear();
-
     // If "Configure CKEditor" button was clicked
     if (!empty($this->_params['ckeditor_config'])) {
       // Suppress the "Saved" status message and redirect to the CKEditor Config page

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -765,7 +765,9 @@ class CRM_Core_Resources {
       $items[] = 'bower_components/smartmenus/dist/jquery.smartmenus.min.js';
       $items[] = 'bower_components/smartmenus/dist/addons/keyboard/jquery.smartmenus.keyboard.min.js';
       $items[] = 'js/crm.menubar.js';
-      $items[] = Civi::service('asset_builder')->getUrl('crm-menubar.css');
+      $items[] = Civi::service('asset_builder')->getUrl('crm-menubar.css', [
+        'color' => Civi::settings()->get('menubar_color'),
+      ]);
       $items[] = [
         'menubar' => [
           'position' => $position,
@@ -844,7 +846,7 @@ class CRM_Core_Resources {
     foreach ($items as $item) {
       $e->content .= file_get_contents(self::singleton()->getPath('civicrm', $item));
     }
-    $color = Civi::settings()->get('menubar_color');
+    $color = $e->params['color'];
     if (!CRM_Utils_Rule::color($color)) {
       $color = Civi::settings()->getDefault('menubar_color');
     }


### PR DESCRIPTION
Overview
----------------------------------------
This simplifies the cache mechanics when manipulating the new `menubar_color` setting.

Before
----------------------------------------
* If you change the `menubar_color` via API/CLI/REST, then it doesn't go live immediately. You have to clear the cache.
* If you determine the `menubar_color` dynamically (e.g. using `civicrm.settings.php` or an extension to set the  on per-domain or per-role or per-user-preference), the different color schemes cannot coexist.

After
----------------------------------------
* Changes go live instantaneously.
* Multiple color schemes can coexist. 
