### PR TITLE
ext/greenwich - Coerce `select2-bootstrap.css` to be handled as SCSS

### DIFF
--- a/ext/greenwich/composer.compile.json
+++ b/ext/greenwich/composer.compile.json
@@ -1,11 +1,16 @@
 {
   "compile": [
     {
+      "title": "Greenwich (Coerce <comment>select2-bootstrap</comment> to SCSS)",
+      "shell": "set -e ; mkdir -p extern/select2 ; cp ../../bower_components/select2/select2-bootstrap.css extern/select2/select2-bootstrap.scss",
+      "watch-files": ["../../bower_components/select2/"]
+    },
+    {
       "title": "Greenwich CSS (<comment>dist/bootstrap3.css</comment>)",
       "php-method": "\\Civi\\Compile\\Scss::build",
-      "watch-files": ["scss"],
+      "watch-files": ["scss", "extern/select2"],
       "scss-files": {"scss/main.scss": "dist/bootstrap3.css"},
-      "scss-includes": ["scss", "extern/bootstrap3/assets/stylesheets", "../../bower_components/select2"]
+      "scss-includes": ["scss", "extern/bootstrap3/assets/stylesheets", "extern/select2"]
     }
   ]
 }


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
