### PR TITLE
Add unit test to demonstrate behaviour with when custom fields are se…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1581,11 +1581,8 @@ SELECT id
     if ($customFields[$customFieldId]['data_type'] == 'Float' ||
       $customFields[$customFieldId]['data_type'] == 'Money'
     ) {
-      if (!$value) {
-        $value = 0;
-      }
 
-      if ($customFields[$customFieldId]['data_type'] == 'Money') {
+      if ($customFields[$customFieldId]['data_type'] == 'Money' && isset($value) && $value !== '') {
         $value = CRM_Utils_Rule::cleanMoney($value);
       }
     }

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -156,6 +156,11 @@ class CRM_Core_BAO_CustomValueTable {
               break;
 
             default:
+              // An empty value should be stored as NULL
+              if (!isset($value) || $value === '') {
+                $type = 'Timestamp';
+                $value = NULL;
+              }
               break;
           }
           if ($value === 'null') {

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -20,6 +20,7 @@
 namespace api\v4\Custom;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\CustomValue;
@@ -321,6 +322,135 @@ class CustomValueTest extends Api4TestBase {
       ->addValue('is_multiple', FALSE)
       ->execute();
     $this->assertNotContains("Custom_$groupName", Entity::get()->execute()->column('name'));
+  }
+
+  public function testCustomValueSaveAsNull(): void {
+    $this->createTestRecord('CustomGroup', [
+      'name' => 'test_nulls',
+    ]);
+    $this->saveTestRecords('CustomField', [
+      'defaults' => ['custom_group_id.name' => 'test_nulls'],
+      'records' => [
+        ['name' => 'string', 'html_type' => 'Text', 'data_type' => 'String'],
+        ['name' => 'select', 'html_type' => 'Select', 'data_type' => 'String', 'serialize' => 1, 'option_values' => ['a' => 'A', 'b' => 'B']],
+        ['name' => 'int', 'html_type' => 'Text', 'data_type' => 'Int'],
+        ['name' => 'float', 'html_type' => 'Text', 'data_type' => 'Float'],
+        ['name' => 'money', 'html_type' => 'Text', 'data_type' => 'Money'],
+        ['name' => 'memo', 'html_type' => 'Text', 'data_type' => 'Memo'],
+        ['name' => 'date', 'html_type' => 'Date', 'data_type' => 'Date'],
+        ['name' => 'stateprovince', 'html_type' => 'Select', 'data_type' => 'StateProvince'],
+        ['name' => 'country', 'html_type' => 'Select', 'data_type' => 'Country'],
+        ['name' => 'link', 'html_type' => 'Text', 'data_type' => 'Link'],
+        ['name' => 'contactref', 'html_type' => 'Autocomplete-Select', 'data_type' => 'ContactReference'],
+        ['name' => 'entityref', 'html_type' => 'Autocomplete-Select', 'data_type' => 'EntityReference', 'fk_entity' => 'Contact'],
+      ],
+    ]);
+
+    $cid = $this->createTestRecord('Contact', [
+      'test_nulls.string' => NULL,
+      'test_nulls.select' => NULL,
+      'test_nulls.int' => NULL,
+      'test_nulls.float' => NULL,
+      'test_nulls.money' => NULL,
+      'test_nulls.memo' => NULL,
+      'test_nulls.date' => NULL,
+      'test_nulls.stateprovince' => NULL,
+      'test_nulls.country' => NULL,
+      'test_nulls.link' => NULL,
+      'test_nulls.contactref' => NULL,
+      'test_nulls.entityref' => NULL,
+    ])['id'];
+
+    $contact = Contact::get(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addSelect('test_nulls.*')
+      ->execute()->single();
+
+    $this->assertSame(NULL, $contact['test_nulls.string']);
+    $this->assertSame(NULL, $contact['test_nulls.select']);
+    $this->assertSame(NULL, $contact['test_nulls.int']);
+    $this->assertSame(NULL, $contact['test_nulls.float']);
+    $this->assertSame(NULL, $contact['test_nulls.money']);
+    $this->assertSame(NULL, $contact['test_nulls.memo']);
+    $this->assertSame(NULL, $contact['test_nulls.date']);
+    $this->assertSame(NULL, $contact['test_nulls.stateprovince']);
+    $this->assertSame(NULL, $contact['test_nulls.country']);
+    $this->assertSame(NULL, $contact['test_nulls.link']);
+    $this->assertSame(NULL, $contact['test_nulls.contactref']);
+    $this->assertSame(NULL, $contact['test_nulls.entityref']);
+
+    Contact::update(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addValue('test_nulls.string', 'test')
+      ->addValue('test_nulls.select', ['a', 'b'])
+      ->addValue('test_nulls.int', 0)
+      ->addValue('test_nulls.float', 0.0)
+      ->addValue('test_nulls.money', 0.0)
+      ->addValue('test_nulls.memo', '<strong>test</strong>')
+      ->addValue('test_nulls.date', '2020-01-01')
+      ->addValue('test_nulls.stateprovince', 1234)
+      ->addValue('test_nulls.country', 1228)
+      ->addValue('test_nulls.link', 'http://example.com')
+      ->addValue('test_nulls.contactref', 1)
+      ->addValue('test_nulls.entityref', 1)
+      ->execute();
+
+    $contact = Contact::get(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addSelect('test_nulls.*')
+      ->execute()->single();
+
+    // Assert all values were set correctly
+    $this->assertSame('test', $contact['test_nulls.string']);
+    $this->assertSame(['a', 'b'], $contact['test_nulls.select']);
+    $this->assertSame(0, $contact['test_nulls.int']);
+    $this->assertSame(0.0, $contact['test_nulls.float']);
+    $this->assertSame(0.00, $contact['test_nulls.money']);
+    $this->assertSame('<strong>test</strong>', $contact['test_nulls.memo']);
+    $this->assertSame('2020-01-01', $contact['test_nulls.date']);
+    $this->assertSame(1234, $contact['test_nulls.stateprovince']);
+    $this->assertSame(1228, $contact['test_nulls.country']);
+    $this->assertSame('http://example.com', $contact['test_nulls.link']);
+    $this->assertSame(1, $contact['test_nulls.contactref']);
+    $this->assertSame(1, $contact['test_nulls.entityref']);
+
+    // Update all values back to NULL
+    Contact::update(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addValue('test_nulls.string', NULL)
+      ->addValue('test_nulls.select', NULL)
+      ->addValue('test_nulls.select', NULL)
+      ->addValue('test_nulls.int', NULL)
+      ->addValue('test_nulls.float', NULL)
+      ->addValue('test_nulls.money', NULL)
+      ->addValue('test_nulls.memo', NULL)
+      ->addValue('test_nulls.date', NULL)
+      ->addValue('test_nulls.stateprovince', NULL)
+      ->addValue('test_nulls.country', NULL)
+      ->addValue('test_nulls.link', NULL)
+      ->addValue('test_nulls.contactref', NULL)
+      ->addValue('test_nulls.entityref', NULL)
+      ->execute();
+
+    // Get the updated contact
+    $contact = Contact::get(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addSelect('test_nulls.*')
+      ->execute()->single();
+
+    // Assert all values are NULL again
+    $this->assertSame(NULL, $contact['test_nulls.string']);
+    $this->assertSame(NULL, $contact['test_nulls.select']);
+    $this->assertSame(NULL, $contact['test_nulls.int']);
+    $this->assertSame(NULL, $contact['test_nulls.float']);
+    $this->assertSame(NULL, $contact['test_nulls.money']);
+    $this->assertSame(NULL, $contact['test_nulls.memo']);
+    $this->assertSame(NULL, $contact['test_nulls.date']);
+    $this->assertSame(NULL, $contact['test_nulls.stateprovince']);
+    $this->assertSame(NULL, $contact['test_nulls.country']);
+    $this->assertSame(NULL, $contact['test_nulls.link']);
+    $this->assertSame(NULL, $contact['test_nulls.contactref']);
+    $this->assertSame(NULL, $contact['test_nulls.entityref']);
   }
 
 }

--- a/tests/phpunit/api/v4/Custom/CustomValueTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomValueTest.php
@@ -332,6 +332,8 @@ class CustomValueTest extends Api4TestBase {
       'defaults' => ['custom_group_id.name' => 'test_nulls'],
       'records' => [
         ['name' => 'string', 'html_type' => 'Text', 'data_type' => 'String'],
+        ['name' => 'default_value_string', 'html_type' => 'Text', 'data_type' => 'String', 'default_value' => 'test'],
+        ['name' => 'default_value_required_string', 'html_type' => 'Text', 'data_type' => 'String', 'default_value' => 'test', 'is_required' => TRUE],
         ['name' => 'select', 'html_type' => 'Select', 'data_type' => 'String', 'serialize' => 1, 'option_values' => ['a' => 'A', 'b' => 'B']],
         ['name' => 'int', 'html_type' => 'Text', 'data_type' => 'Int'],
         ['name' => 'float', 'html_type' => 'Text', 'data_type' => 'Float'],
@@ -348,6 +350,8 @@ class CustomValueTest extends Api4TestBase {
 
     $cid = $this->createTestRecord('Contact', [
       'test_nulls.string' => NULL,
+      'test_nulls.default_value_string' => NULL,
+      'test_nulls.default_value_required_string' => NULL,
       'test_nulls.select' => NULL,
       'test_nulls.int' => NULL,
       'test_nulls.float' => NULL,
@@ -367,6 +371,8 @@ class CustomValueTest extends Api4TestBase {
       ->execute()->single();
 
     $this->assertSame(NULL, $contact['test_nulls.string']);
+    $this->assertSame('test', $contact['test_nulls.default_value_string']);
+    $this->assertSame(NULL, $contact['test_nulls.default_value_required_string']);
     $this->assertSame(NULL, $contact['test_nulls.select']);
     $this->assertSame(NULL, $contact['test_nulls.int']);
     $this->assertSame(NULL, $contact['test_nulls.float']);
@@ -382,6 +388,8 @@ class CustomValueTest extends Api4TestBase {
     Contact::update(FALSE)
       ->addWhere('id', '=', $cid)
       ->addValue('test_nulls.string', 'test')
+      ->addValue('test_nulls.default_value_string', 't')
+      ->addValue('test_nulls.default_value_required_string', 't')
       ->addValue('test_nulls.select', ['a', 'b'])
       ->addValue('test_nulls.int', 0)
       ->addValue('test_nulls.float', 0.0)
@@ -402,6 +410,8 @@ class CustomValueTest extends Api4TestBase {
 
     // Assert all values were set correctly
     $this->assertSame('test', $contact['test_nulls.string']);
+    $this->assertSame('t', $contact['test_nulls.default_value_string']);
+    $this->assertSame('t', $contact['test_nulls.default_value_required_string']);
     $this->assertSame(['a', 'b'], $contact['test_nulls.select']);
     $this->assertSame(0, $contact['test_nulls.int']);
     $this->assertSame(0.0, $contact['test_nulls.float']);
@@ -418,6 +428,8 @@ class CustomValueTest extends Api4TestBase {
     Contact::update(FALSE)
       ->addWhere('id', '=', $cid)
       ->addValue('test_nulls.string', NULL)
+      ->addValue('test_nulls.default_value_string', NULL)
+      ->addValue('test_nulls.default_value_required_string', NULL)
       ->addValue('test_nulls.select', NULL)
       ->addValue('test_nulls.select', NULL)
       ->addValue('test_nulls.int', NULL)
@@ -440,6 +452,8 @@ class CustomValueTest extends Api4TestBase {
 
     // Assert all values are NULL again
     $this->assertSame(NULL, $contact['test_nulls.string']);
+    $this->assertSame('test', $contact['test_nulls.default_value_required_string']);
+    $this->assertSame(NULL, $contact['test_nulls.default_value_string']);
     $this->assertSame(NULL, $contact['test_nulls.select']);
     $this->assertSame(NULL, $contact['test_nulls.int']);
     $this->assertSame(NULL, $contact['test_nulls.float']);


### PR DESCRIPTION
…t to NULL

@colemanw so this fails on my local 

```
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

..F                                                                 3 / 3 (100%)

Time: 00:30.059, Memory: 103.89 MB

There was 1 failure:

1) api\v4\Custom\CustomValueTest::testCustomValueSaveAsNull
Failed asserting that null is identical to 'test'.

/home/seamus/buildkit/build/47-test/web/sites/all/modules/civicrm/tests/phpunit/api/v4/Custom/CustomValueTest.php:455
/home/seamus/buildkit/extern/phpunit9/phpunit9.phar:2538

FAILURES!
Tests: 3, Assertions: 125, Failures: 1.
```

Which suggests we have inconsistent behaviour between creation / update. Also my thinking is that if a field (column) has a default value set and the field is set to required shouldn't the value be being set be the column default not NULL but also L375 seems to be wrong to  me as I re-read my code but I want your opinion on this